### PR TITLE
chore(mcp): add agentdrive CLI as dependency (0.1.5)

### DIFF
--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentdrive-mcp"
-version = "0.1.4"
+version = "0.1.5"
 description = "Agent Drive MCP server for Claude Code"
 readme = "README.md"
 license = "MIT"
@@ -15,6 +15,7 @@ dependencies = [
     "mcp>=1.0.0",
     "httpx>=0.28.0",
     "typer>=0.15.0",
+    "agentdrive>=0.1.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Adds `agentdrive>=0.1.0` as a dependency of `agentdrive-mcp`
- Bumps `agentdrive-mcp` version to 0.1.5
- Users installing via `curl .../install.sh | sh` will now get both `agentdrive-mcp` and `agentdrive` CLI commands

## Test plan
- [ ] CI publishes 0.1.5 to PyPI
- [ ] `pip install agentdrive-mcp` resolves and installs `agentdrive`
- [ ] Both `agentdrive-mcp install` and `agentdrive login` work