### PR TITLE
fix(ingest): offload blocking I/O to thread pool

### DIFF
--- a/src/agentdrive/embedding/pipeline.py
+++ b/src/agentdrive/embedding/pipeline.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import uuid
 from sqlalchemy import select, text
@@ -29,7 +30,9 @@ async def embed_file_chunks(
         batch = chunks[i:i + BATCH_SIZE]
         texts = [f"{c.context_prefix}\n{c.content}" if c.context_prefix else c.content for c in batch]
         content_type = batch[0].content_type
-        vectors_full = client.embed(texts, input_type="document", content_type=content_type)
+        vectors_full = await asyncio.to_thread(
+            client.embed, texts, input_type="document", content_type=content_type
+        )
 
         for chunk, vector in zip(batch, vectors_full):
             vector_256 = client.truncate(vector, 256)
@@ -71,7 +74,9 @@ async def embed_file_aliases(
         batch = aliases[i:i + BATCH_SIZE]
         texts = [a.content for a in batch]
         # Aliases are synthetic questions — embed as queries for better matching
-        vectors = client.embed(texts, input_type="query", content_type="text")
+        vectors = await asyncio.to_thread(
+            client.embed, texts, input_type="query", content_type="text"
+        )
 
         for alias, vector in zip(batch, vectors):
             vec_256 = client.truncate(vector, 256)

--- a/src/agentdrive/services/ingest.py
+++ b/src/agentdrive/services/ingest.py
@@ -1,5 +1,7 @@
+import asyncio
 import logging
 import uuid
+from pathlib import Path
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -118,20 +120,35 @@ async def _get_summary(
     return result.scalar_one_or_none()
 
 
+def _download_and_chunk(
+    gcs_path: str, content_type: str, filename: str, file_id: str
+) -> tuple[list[ParentChildChunks], Path]:
+    """Sync I/O: download from GCS and chunk. Runs in a thread pool."""
+    storage = StorageService()
+    tmp_path = storage.download_to_tempfile(gcs_path)
+    try:
+        chunk_groups = registry.chunk_file(
+            content_type,
+            tmp_path,
+            filename,
+            gcs_path=gcs_path,
+            file_id=file_id,
+        )
+        return chunk_groups, tmp_path
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
 async def _phase1_chunking(
     file: File, session: AsyncSession
 ) -> list[FileBatch]:
     """Download file, chunk it, persist batches + chunks. Returns empty list if 0 chunks."""
-    storage = StorageService()
     tmp_path = None
     try:
-        tmp_path = storage.download_to_tempfile(file.gcs_path)
-        chunk_groups = registry.chunk_file(
-            file.content_type,
-            tmp_path,
-            file.filename,
-            gcs_path=file.gcs_path,
-            file_id=str(file.id),
+        chunk_groups, tmp_path = await asyncio.to_thread(
+            _download_and_chunk,
+            file.gcs_path, file.content_type, file.filename, str(file.id),
         )
 
         if not chunk_groups or sum(len(g.children) for g in chunk_groups) == 0:


### PR DESCRIPTION
## Summary
- GCS downloads, Document AI parsing, and Voyage AI embedding were running as sync calls on the async event loop, blocking health checks and causing Cloud Run to kill instances during PDF processing
- Extracted sync I/O (download + chunking) into `_download_and_chunk()` and wrapped with `asyncio.to_thread()` so the event loop stays free
- Wrapped Voyage AI `client.embed()` calls in `asyncio.to_thread()` in the embedding pipeline

## Test plan
- [x] 221 tests pass locally (1 pre-existing e2e DB auth error unrelated)
- [ ] Deploy to Cloud Run and upload PDFs to verify health checks stay healthy during processing
- [ ] Monitor `/health` probe logs to confirm no more timeout kills