### PR TITLE
feat: hierarchical summarization for large documents (#27)

### DIFF
--- a/docs/superpowers/plans/2026-04-03-hierarchical-summarization.md
+++ b/docs/superpowers/plans/2026-04-03-hierarchical-summarization.md
@@ -1,0 +1,708 @@
+# Hierarchical Summarization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a token threshold gate to Phase 2 summarization so documents over 200k tokens use map-reduce instead of a single LLM call.
+
+**Architecture:** A `count_tokens` check in `_phase2_summarization` routes to the existing single-call path (≤200k) or a new hierarchical path (>200k). The hierarchical path batches parent chunks into ~50k-token groups, summarizes each concurrently, then reduces into the final `FileSummary`. Output contract is unchanged.
+
+**Tech Stack:** Python asyncio, OpenAI SDK (Gemini via Google AI Studio), tiktoken, pytest
+
+**Spec:** `docs/superpowers/specs/2026-04-03-hierarchical-summarization-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/agentdrive/enrichment/client.py` | Modify | Add `generate_group_summary()` and `generate_reduce_summary()` methods + prompts |
+| `src/agentdrive/enrichment/contextual.py` | Modify | Add `generate_group_summary()` and `generate_reduce_summary()` thin wrappers |
+| `src/agentdrive/services/ingest.py` | Modify | Add token gate, `_batch_parents()`, `_hierarchical_summarize()` |
+| `tests/enrichment/test_client.py` | Modify | Tests for new client methods |
+| `tests/test_summarization.py` | Create | Tests for batching logic and threshold routing |
+
+---
+
+### Task 1: Add map prompt and `generate_group_summary()` to EnrichmentClient
+
+**Files:**
+- Modify: `src/agentdrive/enrichment/client.py`
+- Test: `tests/enrichment/test_client.py`
+
+- [ ] **Step 1: Write failing test for `generate_group_summary`**
+
+Add to `tests/enrichment/test_client.py`:
+
+```python
+@pytest.mark.asyncio
+@patch("agentdrive.enrichment.client.openai.AsyncOpenAI")
+async def test_generate_group_summary(mock_openai_cls):
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create.return_value = _mock_chat_response(
+        '{"summary": "This section covers revenue.", "section_summaries": [{"heading": "Q3 Revenue", "summary": "Revenue grew 34%."}]}'
+    )
+    mock_openai_cls.return_value = mock_client
+
+    client = EnrichmentClient()
+    result = await client.generate_group_summary(
+        group_text="Q3 revenue reached $4.2M, up 34% YoY...",
+        group_index=1,
+        total_groups=4,
+    )
+
+    assert result["summary"] == "This section covers revenue."
+    assert len(result["section_summaries"]) == 1
+    call_args = mock_client.chat.completions.create.call_args
+    assert call_args[1]["response_format"] == {"type": "json_object"}
+    content = call_args[1]["messages"][0]["content"]
+    assert "section 1 of 4" in content
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/enrichment/test_client.py::test_generate_group_summary -v`
+Expected: FAIL — `EnrichmentClient` has no attribute `generate_group_summary`
+
+- [ ] **Step 3: Implement `generate_group_summary` in client.py**
+
+Add prompt constant after `CONTEXT_WITH_SUMMARY_PROMPT` (after line 44):
+
+```python
+GROUP_SUMMARY_PROMPT = """You are summarizing section {group_index} of {total_groups} of a larger document. Produce:
+1. A summary of this section (2-3 sentences)
+2. section_summaries (a list of objects with "heading" and "summary" for each major section within this portion)
+
+<document_section>
+{group_text}
+</document_section>
+
+Return valid JSON with this exact structure:
+{{"summary": "...", "section_summaries": [{{"heading": "...", "summary": "..."}}]}}"""
+```
+
+Add method to `EnrichmentClient` class (after `generate_summary`):
+
+```python
+async def generate_group_summary(
+    self, group_text: str, group_index: int, total_groups: int
+) -> dict:
+    """Summarize a group of parent chunks (map phase of hierarchical summarization)."""
+    try:
+        response = await self._client.chat.completions.create(
+            model=settings.enrichment_model,
+            max_tokens=16384,
+            response_format={"type": "json_object"},
+            messages=[
+                {
+                    "role": "user",
+                    "content": GROUP_SUMMARY_PROMPT.format(
+                        group_text=group_text,
+                        group_index=group_index,
+                        total_groups=total_groups,
+                    ),
+                }
+            ],
+        )
+        text = (response.choices[0].message.content or "").strip()
+        return json.loads(text)
+    except Exception as e:
+        logger.warning(f"Group summary generation failed: {e}")
+        return {"summary": "", "section_summaries": []}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/enrichment/test_client.py::test_generate_group_summary -v`
+Expected: PASS
+
+- [ ] **Step 5: Write failing test for error fallback**
+
+Add to `tests/enrichment/test_client.py`:
+
+```python
+@pytest.mark.asyncio
+@patch("agentdrive.enrichment.client.openai.AsyncOpenAI")
+async def test_generate_group_summary_fallback_on_error(mock_openai_cls):
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create.side_effect = Exception("API error")
+    mock_openai_cls.return_value = mock_client
+
+    client = EnrichmentClient()
+    result = await client.generate_group_summary("text", 1, 4)
+
+    assert result == {"summary": "", "section_summaries": []}
+```
+
+- [ ] **Step 6: Run test to verify it passes** (fallback already implemented)
+
+Run: `uv run pytest tests/enrichment/test_client.py::test_generate_group_summary_fallback_on_error -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/agentdrive/enrichment/client.py tests/enrichment/test_client.py
+git commit -m "feat(enrichment): add generate_group_summary for map phase (#27)"
+```
+
+---
+
+### Task 2: Add reduce prompt and `generate_reduce_summary()` to EnrichmentClient
+
+**Files:**
+- Modify: `src/agentdrive/enrichment/client.py`
+- Test: `tests/enrichment/test_client.py`
+
+- [ ] **Step 1: Write failing test for `generate_reduce_summary`**
+
+Add to `tests/enrichment/test_client.py`:
+
+```python
+@pytest.mark.asyncio
+@patch("agentdrive.enrichment.client.openai.AsyncOpenAI")
+async def test_generate_reduce_summary(mock_openai_cls):
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create.return_value = _mock_chat_response(
+        '{"document_summary": "Annual financial report.", "section_summaries": [{"heading": "Revenue", "summary": "Revenue grew."}]}'
+    )
+    mock_openai_cls.return_value = mock_client
+
+    group_summaries = [
+        {"summary": "Section covers revenue.", "section_summaries": [{"heading": "Q3 Revenue", "summary": "Revenue grew 34%."}]},
+        {"summary": "Section covers expenses.", "section_summaries": [{"heading": "Operating Costs", "summary": "Costs decreased."}]},
+    ]
+
+    client = EnrichmentClient()
+    result = await client.generate_reduce_summary(group_summaries)
+
+    assert result["document_summary"] == "Annual financial report."
+    assert len(result["section_summaries"]) == 1
+    call_args = mock_client.chat.completions.create.call_args
+    assert call_args[1]["response_format"] == {"type": "json_object"}
+    content = call_args[1]["messages"][0]["content"]
+    assert "Group 1" in content
+    assert "Group 2" in content
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/enrichment/test_client.py::test_generate_reduce_summary -v`
+Expected: FAIL — `EnrichmentClient` has no attribute `generate_reduce_summary`
+
+- [ ] **Step 3: Implement `generate_reduce_summary` in client.py**
+
+Add prompt constant after `GROUP_SUMMARY_PROMPT`:
+
+```python
+REDUCE_SUMMARY_PROMPT = """Below are summaries of consecutive sections of a large document. Synthesize them into:
+1. A document_summary (2-3 sentences describing the document's purpose, parties involved, and subject matter)
+2. section_summaries (a merged, deduplicated list of objects with "heading" and "summary" covering the entire document)
+
+{group_summaries_text}
+
+Return valid JSON with this exact structure:
+{{"document_summary": "...", "section_summaries": [{{"heading": "...", "summary": "..."}}]}}"""
+```
+
+Add method to `EnrichmentClient` class (after `generate_group_summary`):
+
+```python
+async def generate_reduce_summary(self, group_summaries: list[dict]) -> dict:
+    """Synthesize group summaries into a final document summary (reduce phase)."""
+    parts = []
+    for i, group in enumerate(group_summaries, 1):
+        sections_text = "\n".join(
+            f"  - {s['heading']}: {s['summary']}"
+            for s in group.get("section_summaries", [])
+        )
+        parts.append(
+            f"Group {i} (of {len(group_summaries)}):\n"
+            f"Summary: {group.get('summary', '')}\n"
+            f"Sections:\n{sections_text}"
+        )
+    group_summaries_text = "\n\n".join(parts)
+
+    try:
+        response = await self._client.chat.completions.create(
+            model=settings.enrichment_model,
+            max_tokens=16384,
+            response_format={"type": "json_object"},
+            messages=[
+                {
+                    "role": "user",
+                    "content": REDUCE_SUMMARY_PROMPT.format(
+                        group_summaries_text=group_summaries_text
+                    ),
+                }
+            ],
+        )
+        text = (response.choices[0].message.content or "").strip()
+        return json.loads(text)
+    except Exception as e:
+        logger.warning(f"Reduce summary generation failed: {e}")
+        return {"document_summary": "", "section_summaries": []}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/enrichment/test_client.py::test_generate_reduce_summary -v`
+Expected: PASS
+
+- [ ] **Step 5: Write failing test for error fallback**
+
+Add to `tests/enrichment/test_client.py`:
+
+```python
+@pytest.mark.asyncio
+@patch("agentdrive.enrichment.client.openai.AsyncOpenAI")
+async def test_generate_reduce_summary_fallback_on_error(mock_openai_cls):
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create.side_effect = Exception("API error")
+    mock_openai_cls.return_value = mock_client
+
+    client = EnrichmentClient()
+    result = await client.generate_reduce_summary([{"summary": "test", "section_summaries": []}])
+
+    assert result == {"document_summary": "", "section_summaries": []}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `uv run pytest tests/enrichment/test_client.py::test_generate_reduce_summary_fallback_on_error -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/agentdrive/enrichment/client.py tests/enrichment/test_client.py
+git commit -m "feat(enrichment): add generate_reduce_summary for reduce phase (#27)"
+```
+
+---
+
+### Task 3: Add `generate_group_summary` and `generate_reduce_summary` wrappers to contextual.py
+
+**Files:**
+- Modify: `src/agentdrive/enrichment/contextual.py`
+
+Note: These are one-line delegation wrappers matching the existing `generate_document_summary` pattern. Existing wrappers in this file have no dedicated tests — the client methods are tested directly in `test_client.py`.
+
+- [ ] **Step 1: Add thin wrappers**
+
+Add after `generate_document_summary` (after line 41 in contextual.py):
+
+```python
+async def generate_group_summary(
+    group_text: str, group_index: int, total_groups: int
+) -> dict:
+    """Summarize a group of parent chunks (map phase of hierarchical summarization)."""
+    client = EnrichmentClient()
+    return await client.generate_group_summary(group_text, group_index, total_groups)
+
+
+async def generate_reduce_summary(group_summaries: list[dict]) -> dict:
+    """Synthesize group summaries into a final document summary (reduce phase)."""
+    client = EnrichmentClient()
+    return await client.generate_reduce_summary(group_summaries)
+```
+
+- [ ] **Step 2: Run existing tests to verify no regressions**
+
+Run: `uv run pytest tests/enrichment/ -v`
+Expected: All existing tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/agentdrive/enrichment/contextual.py
+git commit -m "feat(enrichment): add group/reduce summary wrappers in contextual.py (#27)"
+```
+
+---
+
+### Task 4: Add `_batch_parents()` helper to ingest.py
+
+**Files:**
+- Modify: `src/agentdrive/services/ingest.py`
+- Create: `tests/test_summarization.py`
+
+- [ ] **Step 1: Write failing tests for `_batch_parents`**
+
+Create `tests/test_summarization.py`:
+
+```python
+from dataclasses import dataclass
+
+import pytest
+
+from agentdrive.services.ingest import _batch_parents, GROUP_BATCH_TOKENS
+
+
+@dataclass
+class FakeParent:
+    content: str
+    token_count: int
+
+
+def _make_parent(tokens: int) -> FakeParent:
+    """Create a fake parent with approximate content length for given token count."""
+    return FakeParent(content="x " * tokens, token_count=tokens)
+
+
+def test_batch_parents_single_batch():
+    """All parents fit in one batch."""
+    parents = [_make_parent(1000) for _ in range(3)]
+    batches = _batch_parents(parents)
+    assert len(batches) == 1
+    assert len(batches[0]) == 3
+
+
+def test_batch_parents_multiple_batches():
+    """Parents split across batches at GROUP_BATCH_TOKENS boundary."""
+    # 5 parents at 20k each = 100k total. Batching: [p1+p2]=40k, [p3+p4]=40k, [p5]=20k → 3 batches
+    parents = [_make_parent(20_000) for _ in range(5)]
+    batches = _batch_parents(parents)
+    assert len(batches) == 3
+    # All parents accounted for
+    total = sum(len(b) for b in batches)
+    assert total == 5
+
+
+def test_batch_parents_oversized_single_parent():
+    """A parent exceeding GROUP_BATCH_TOKENS gets its own batch."""
+    parents = [
+        _make_parent(60_000),  # exceeds 50k, gets own batch
+        _make_parent(10_000),
+        _make_parent(10_000),
+    ]
+    batches = _batch_parents(parents)
+    assert len(batches) == 2
+    assert len(batches[0]) == 1  # oversized parent alone
+    assert len(batches[1]) == 2  # remaining two fit together
+
+
+def test_batch_parents_empty():
+    """No parents produces no batches."""
+    batches = _batch_parents([])
+    assert batches == []
+
+
+def test_batch_parents_preserves_order():
+    """Batches preserve original parent ordering."""
+    parents = [_make_parent(20_000) for _ in range(4)]
+    batches = _batch_parents(parents)
+    flat = [p for batch in batches for p in batch]
+    assert flat == parents
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_summarization.py -v`
+Expected: FAIL — `_batch_parents` not found in `agentdrive.services.ingest`
+
+- [ ] **Step 3: Implement `_batch_parents` in ingest.py**
+
+Add constants after imports (near other module-level code). Note: `_batch_parents` uses the pre-computed `parent.token_count` attribute, not `count_tokens()` — the token counting happened during Phase 1 chunking.
+
+```python
+MAX_SINGLE_PASS_TOKENS = 200_000
+GROUP_BATCH_TOKENS = 50_000
+```
+
+Add helper function before `_phase2_summarization`:
+
+```python
+def _batch_parents(parents: list) -> list[list]:
+    """Group parent chunks into batches of ~GROUP_BATCH_TOKENS tokens each."""
+    if not parents:
+        return []
+    batches: list[list] = []
+    current_batch: list = []
+    current_tokens = 0
+
+    for parent in parents:
+        token_count = parent.token_count
+        if current_batch and current_tokens + token_count > GROUP_BATCH_TOKENS:
+            batches.append(current_batch)
+            current_batch = []
+            current_tokens = 0
+        current_batch.append(parent)
+        current_tokens += token_count
+
+    if current_batch:
+        batches.append(current_batch)
+    return batches
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_summarization.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentdrive/services/ingest.py tests/test_summarization.py
+git commit -m "feat(ingest): add _batch_parents helper for hierarchical summarization (#27)"
+```
+
+---
+
+### Task 5: Add `_hierarchical_summarize()` and wire up the threshold gate
+
+**Files:**
+- Modify: `src/agentdrive/services/ingest.py`
+- Modify: `tests/test_summarization.py`
+
+- [ ] **Step 1: Write failing tests for threshold routing**
+
+Add to `tests/test_summarization.py`:
+
+```python
+import asyncio
+from unittest.mock import AsyncMock, patch, MagicMock
+from uuid import uuid4
+
+from agentdrive.services.ingest import _phase2_summarization, MAX_SINGLE_PASS_TOKENS
+
+
+def _mock_session(parents):
+    """Create a mock AsyncSession that returns given parents from execute()."""
+    session = MagicMock()
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = parents
+    # session.execute is async, returns result_mock
+    session.execute = AsyncMock(return_value=result_mock)
+    # session.add is sync (SQLAlchemy), session.commit is async
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    return session
+
+
+@pytest.mark.asyncio
+@patch("agentdrive.services.ingest.generate_document_summary", new_callable=AsyncMock)
+async def test_phase2_small_doc_uses_single_pass(mock_gen_summary):
+    """Documents under MAX_SINGLE_PASS_TOKENS use generate_document_summary directly."""
+    mock_gen_summary.return_value = {
+        "document_summary": "A short doc.",
+        "section_summaries": [],
+    }
+
+    file = MagicMock(id=uuid4())
+    parent = MagicMock(content="short text", token_count=100)
+    session = _mock_session([parent])
+
+    summary = await _phase2_summarization(file, session)
+
+    mock_gen_summary.assert_called_once()
+    assert summary.document_summary == "A short doc."
+
+
+@pytest.mark.asyncio
+@patch("agentdrive.services.ingest._hierarchical_summarize", new_callable=AsyncMock)
+@patch("agentdrive.services.ingest.generate_document_summary", new_callable=AsyncMock)
+async def test_phase2_large_doc_uses_hierarchical(mock_gen_summary, mock_hier):
+    """Documents over MAX_SINGLE_PASS_TOKENS use _hierarchical_summarize."""
+    mock_hier.return_value = {
+        "document_summary": "A large doc.",
+        "section_summaries": [{"heading": "Intro", "summary": "Intro text."}],
+    }
+
+    file = MagicMock(id=uuid4())
+    # Each parent has 50k tokens, 5 parents = 250k > 200k threshold
+    parents = [MagicMock(content="x " * 1000, token_count=50_000) for _ in range(5)]
+    session = _mock_session(parents)
+
+    summary = await _phase2_summarization(file, session)
+
+    mock_gen_summary.assert_not_called()
+    mock_hier.assert_called_once()
+    assert summary.document_summary == "A large doc."
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_summarization.py::test_phase2_small_doc_uses_single_pass tests/test_summarization.py::test_phase2_large_doc_uses_hierarchical -v`
+Expected: FAIL — `_hierarchical_summarize` not found (the token gate and function don't exist yet)
+
+- [ ] **Step 3: Implement `_hierarchical_summarize` and modify `_phase2_summarization`**
+
+Add imports at top of `ingest.py` (add to the existing `from agentdrive.enrichment.contextual import` block):
+
+```python
+from agentdrive.enrichment.contextual import (
+    enrich_chunks_with_summaries,
+    generate_document_summary,
+    generate_group_summary,
+    generate_reduce_summary,
+)
+```
+
+Note: `enrich_chunks_with_summaries` and `generate_document_summary` are already imported — just add `generate_group_summary` and `generate_reduce_summary` to the existing import. Do NOT import `EnrichmentClient` directly — ingest.py talks to contextual.py wrappers only.
+
+Add `_hierarchical_summarize` before `_phase2_summarization`:
+
+```python
+async def _hierarchical_summarize(parents: list) -> dict:
+    """Map-reduce summarization for large documents."""
+    batches = _batch_parents(parents)
+    semaphore = asyncio.Semaphore(5)
+
+    async def summarize_group(batch: list, index: int) -> dict:
+        async with semaphore:
+            group_text = "\n\n".join(p.content for p in batch)
+            return await generate_group_summary(group_text, index, len(batches))
+
+    group_summaries = await asyncio.gather(
+        *(summarize_group(batch, i + 1) for i, batch in enumerate(batches))
+    )
+
+    return await generate_reduce_summary(list(group_summaries))
+```
+
+Modify `_phase2_summarization` to add the threshold gate. Replace lines 228-230:
+
+```python
+    # Old:
+    # document_text = "\n\n".join(p.content for p in parents)
+    # summary_data = await generate_document_summary(document_text)
+
+    # New:
+    total_tokens = sum(p.token_count for p in parents)
+
+    if total_tokens > MAX_SINGLE_PASS_TOKENS:
+        logger.info(
+            f"File {file.id}: {total_tokens} tokens exceeds threshold, using hierarchical summarization"
+        )
+        summary_data = await _hierarchical_summarize(parents)
+    else:
+        document_text = "\n\n".join(p.content for p in parents)
+        summary_data = await generate_document_summary(document_text)
+```
+
+- [ ] **Step 4: Run all summarization tests**
+
+Run: `uv run pytest tests/test_summarization.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run full test suite to verify no regressions**
+
+Run: `uv run pytest tests/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentdrive/services/ingest.py tests/test_summarization.py
+git commit -m "feat(ingest): add hierarchical summarization with 200k token threshold (#27)"
+```
+
+---
+
+### Task 6: Add end-to-end test for `_hierarchical_summarize`
+
+**Files:**
+- Modify: `tests/test_summarization.py`
+
+The spec requires "hierarchical path tests" — a test that verifies the full map-reduce flow: batching → group summary calls → reduce call.
+
+- [ ] **Step 1: Write failing test for `_hierarchical_summarize` end-to-end**
+
+Add to `tests/test_summarization.py`:
+
+```python
+@pytest.mark.asyncio
+@patch("agentdrive.services.ingest.generate_reduce_summary", new_callable=AsyncMock)
+@patch("agentdrive.services.ingest.generate_group_summary", new_callable=AsyncMock)
+async def test_hierarchical_summarize_map_reduce_flow(mock_group, mock_reduce):
+    """Verifies map phase calls generate_group_summary per batch, then reduce combines them."""
+    from agentdrive.services.ingest import _hierarchical_summarize
+
+    mock_group.side_effect = [
+        {"summary": "Group 1 summary.", "section_summaries": [{"heading": "A", "summary": "a"}]},
+        {"summary": "Group 2 summary.", "section_summaries": [{"heading": "B", "summary": "b"}]},
+    ]
+    mock_reduce.return_value = {
+        "document_summary": "Full doc summary.",
+        "section_summaries": [{"heading": "A", "summary": "a"}, {"heading": "B", "summary": "b"}],
+    }
+
+    # 4 parents at 30k tokens each = 120k total → 2 batches at 50k threshold
+    parents = [MagicMock(content=f"content {i}", token_count=30_000) for i in range(4)]
+
+    result = await _hierarchical_summarize(parents)
+
+    # Map phase: 2 batches → 2 group summary calls
+    assert mock_group.call_count == 2
+    # Reduce phase: called once with both group summaries
+    mock_reduce.assert_called_once()
+    reduce_args = mock_reduce.call_args[0][0]
+    assert len(reduce_args) == 2
+    assert result["document_summary"] == "Full doc summary."
+    assert len(result["section_summaries"]) == 2
+```
+
+- [ ] **Step 2: Run test to verify it passes** (implementation already done in Task 5)
+
+Run: `uv run pytest tests/test_summarization.py::test_hierarchical_summarize_map_reduce_flow -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_summarization.py
+git commit -m "test: add end-to-end test for hierarchical map-reduce flow (#27)"
+```
+
+---
+
+### Task 7: Update conftest.py mocks and final verification
+
+**Files:**
+- Modify: `tests/conftest.py`
+
+- [ ] **Step 1: Add mocks for new enrichment functions**
+
+The autouse fixture mocks enrichment functions at the ingest module level. Both `generate_group_summary` and `generate_reduce_summary` are now imported into ingest.py and need mocking for integration tests. (Integration tests use small test data that won't exceed the 200k threshold, so these mocks are a safety net, not functionally triggered.)
+
+Add to the `mock_enrichment_and_embedding` fixture in `conftest.py` (after the existing `generate_document_summary` mock):
+
+```python
+mocker.patch(
+    "agentdrive.services.ingest.generate_group_summary",
+    new_callable=AsyncMock,
+    return_value={"summary": "", "section_summaries": []},
+)
+mocker.patch(
+    "agentdrive.services.ingest.generate_reduce_summary",
+    new_callable=AsyncMock,
+    return_value={"document_summary": "", "section_summaries": []},
+)
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `uv run pytest tests/ -v`
+Expected: All PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/conftest.py
+git commit -m "test: mock group/reduce summary functions in conftest (#27)"
+```
+
+---
+
+### Task 8: Final cleanup and verification
+
+- [ ] **Step 1: Run full test suite one more time**
+
+Run: `uv run pytest tests/ -v`
+Expected: All PASS
+
+- [ ] **Step 2: Verify the feature branch is clean**
+
+Run: `git status && git log --oneline -10`
+Expected: Clean working tree, all commits present

--- a/docs/superpowers/specs/2026-04-03-hierarchical-summarization-design.md
+++ b/docs/superpowers/specs/2026-04-03-hierarchical-summarization-design.md
@@ -37,7 +37,7 @@ _phase2_summarization(file, session)
     │   └─ generate_group_summary(group_text)
     │       returns { "summary": "...", "section_summaries": [...] }
     ├─ Collect all intermediate summaries
-    └─ Reduce phase: generate_document_summary(intermediates)
+    └─ Reduce phase: generate_reduce_summary(group_summaries)
         returns { "document_summary": "...", "section_summaries": [...] }
 ```
 
@@ -113,7 +113,7 @@ Same `max_tokens=16384` for both map and reduce calls.
 |------|--------|
 | `services/ingest.py` | Token check, `_batch_parents()` helper, `_hierarchical_summarize()` orchestration with semaphore |
 | `enrichment/client.py` | New `generate_group_summary()` (map) and `generate_reduce_summary()` (reduce) methods with dedicated prompts |
-| `enrichment/contextual.py` | New `generate_group_summary()` thin wrapper (mirrors `generate_document_summary()` pattern) |
+| `enrichment/contextual.py` | New `generate_group_summary()` and `generate_reduce_summary()` thin wrappers (mirrors `generate_document_summary()` pattern) |
 | `tests/` | Batch logic tests, threshold routing tests, hierarchical path tests |
 
 ## Files NOT Changed

--- a/docs/superpowers/specs/2026-04-03-hierarchical-summarization-design.md
+++ b/docs/superpowers/specs/2026-04-03-hierarchical-summarization-design.md
@@ -78,35 +78,48 @@ New method `EnrichmentClient.generate_group_summary()`:
 
 ### Reduce Phase
 
-Reuses existing `generate_document_summary()` with concatenated group summaries as input instead of raw document text. No changes to the function or its prompt.
+New method `EnrichmentClient.generate_reduce_summary()` with a dedicated prompt. The existing `SUMMARY_PROMPT` wraps input in `<document>` tags and says "Analyze this document" — feeding it pre-summarized text would confuse the model. The reduce prompt instead instructs the LLM to synthesize group summaries into a single coherent summary, merging and deduplicating section summaries across groups.
 
 Reduce input format:
 
 ```
-Group 1 summary: ...
-Sections: ...
+Group 1 (of 4):
+Summary: ...
+Sections:
+- Introduction: ...
+- Background: ...
 
-Group 2 summary: ...
-Sections: ...
+Group 2 (of 4):
+Summary: ...
+Sections:
+- Methodology: ...
 ```
+
+Returns the same schema as `generate_document_summary()`: `{ "document_summary": "...", "section_summaries": [...] }`. The LLM handles merging/deduplication of section summaries across groups into a single flat list.
+
+### Concurrency
+
+Map phase calls run concurrently via `asyncio.gather` with a semaphore (max 5 concurrent). At 200k/50k = ~4 calls this rarely matters, but protects against very large documents producing 20+ batches.
 
 ### Token Settings
 
 Same `max_tokens=16384` for both map and reduce calls.
 
+**Note:** Token counts use `cl100k_base` tokenizer (tiktoken), not Gemini's native tokenizer. The counts are approximate but close enough for a threshold-based safety valve.
+
 ## Files Changed
 
 | File | Change |
 |------|--------|
-| `services/ingest.py` | Token check, `_batch_parents()` helper, `_hierarchical_summarize()` orchestration |
-| `enrichment/client.py` | New `generate_group_summary()` method |
-| `enrichment/contextual.py` | New `generate_group_summaries()` entry point |
+| `services/ingest.py` | Token check, `_batch_parents()` helper, `_hierarchical_summarize()` orchestration with semaphore |
+| `enrichment/client.py` | New `generate_group_summary()` (map) and `generate_reduce_summary()` (reduce) methods with dedicated prompts |
+| `enrichment/contextual.py` | New `generate_group_summary()` thin wrapper (mirrors `generate_document_summary()` pattern) |
 | `tests/` | Batch logic tests, threshold routing tests, hierarchical path tests |
 
 ## Files NOT Changed
 
 - `models/file_summary.py` — no schema changes
-- `enrichment/client.py` existing methods — untouched
+- `enrichment/client.py` existing methods (`generate_summary`, `generate_context`) — untouched
 - `chunking/` — untouched
 - Phase 3 (enrichment), Phase 4 (embedding) — untouched
 - `config.py` — no new settings
@@ -118,3 +131,7 @@ Same `max_tokens=16384` for both map and reduce calls.
 - No contract changes (FileSummary output identical)
 - Existing path for docs ≤ 200k tokens is completely untouched
 - Low risk
+
+## Error Handling
+
+Map phase calls follow the same pattern as existing `generate_summary()`: catch exceptions, log warning, return fallback. If a group summary fails, it returns `{"summary": "", "section_summaries": []}`. The reduce phase proceeds with whatever groups succeeded — a partial summary is better than no summary. If all groups fail, the reduce phase receives empty input and produces an empty summary (same fallback as today's single-call failure mode).

--- a/docs/superpowers/specs/2026-04-03-hierarchical-summarization-design.md
+++ b/docs/superpowers/specs/2026-04-03-hierarchical-summarization-design.md
@@ -1,0 +1,120 @@
+# Hierarchical Summarization for Large Documents
+
+**Issue:** #27
+**Date:** 2026-04-03
+**Status:** Approved
+
+## Problem
+
+`_phase2_summarization` in `services/ingest.py` concatenates all parent chunks into a single string and sends it as one LLM call to Gemini 2.5 Flash. For very large documents, this risks context window overflow, degraded summary quality, and unnecessary cost.
+
+Current upper bound is ~100 pages (~70k tokens), which is fine today. This change adds a safety valve for when document sizes grow.
+
+## Decision
+
+**Approach A: Threshold gate** — add a token count check in `_phase2_summarization`. Documents under 200k tokens use the existing single-call path (unchanged). Documents over 200k tokens use a map-reduce hierarchical path.
+
+Rejected alternatives:
+- **Strategy classes** — over-engineered for a rarely-triggered branch
+- **Always map-reduce** — changes working behavior for no benefit on small docs
+
+## Design
+
+### Flow
+
+```
+_phase2_summarization(file, session)
+│
+├─ Query all ParentChunks (unchanged)
+├─ count_tokens(concatenated text)
+│
+├─ ≤ 200k tokens
+│   └─ generate_document_summary(text)          ← existing path, untouched
+│
+└─ > 200k tokens
+    ├─ Batch parents into groups (~50k tokens each)
+    ├─ Map phase: for each group (concurrent via asyncio.gather):
+    │   └─ generate_group_summary(group_text)
+    │       returns { "summary": "...", "section_summaries": [...] }
+    ├─ Collect all intermediate summaries
+    └─ Reduce phase: generate_document_summary(intermediates)
+        returns { "document_summary": "...", "section_summaries": [...] }
+```
+
+Output contract is identical regardless of path. `FileSummary` gets the same `document_summary` + `section_summaries`. Phase 3 enrichment is unaffected.
+
+### Batching
+
+- Target batch size: **50k tokens**
+- Never split a parent chunk across batches
+- If a single parent exceeds 50k, it gets its own batch
+- At 200k threshold / 50k per batch = ~4 parallel map calls + 1 reduce call
+
+### Constants
+
+```python
+MAX_SINGLE_PASS_TOKENS = 200_000
+GROUP_BATCH_TOKENS = 50_000
+```
+
+Defined as constants in `services/ingest.py`. No config setting needed.
+
+### Map Phase Prompt
+
+New method `EnrichmentClient.generate_group_summary()`:
+
+```
+"You are summarizing section {group_index} of {total_groups}
+ of a larger document. Produce:
+ 1. A summary of this section (2-3 sentences)
+ 2. section_summaries for each major section within this portion
+
+ <document_section>
+ {group_text}
+ </document_section>
+
+ Return JSON: {"summary": "...", "section_summaries": [{"heading": "...", "summary": "..."}]}"
+```
+
+### Reduce Phase
+
+Reuses existing `generate_document_summary()` with concatenated group summaries as input instead of raw document text. No changes to the function or its prompt.
+
+Reduce input format:
+
+```
+Group 1 summary: ...
+Sections: ...
+
+Group 2 summary: ...
+Sections: ...
+```
+
+### Token Settings
+
+Same `max_tokens=16384` for both map and reduce calls.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `services/ingest.py` | Token check, `_batch_parents()` helper, `_hierarchical_summarize()` orchestration |
+| `enrichment/client.py` | New `generate_group_summary()` method |
+| `enrichment/contextual.py` | New `generate_group_summaries()` entry point |
+| `tests/` | Batch logic tests, threshold routing tests, hierarchical path tests |
+
+## Files NOT Changed
+
+- `models/file_summary.py` — no schema changes
+- `enrichment/client.py` existing methods — untouched
+- `chunking/` — untouched
+- Phase 3 (enrichment), Phase 4 (embedding) — untouched
+- `config.py` — no new settings
+
+## Scope
+
+- ~3 files modified, ~80-100 lines added
+- No schema changes
+- No contract changes (FileSummary output identical)
+- Existing path for docs ≤ 200k tokens is completely untouched
+- Low risk

--- a/src/agentdrive/enrichment/client.py
+++ b/src/agentdrive/enrichment/client.py
@@ -43,6 +43,17 @@ Here is the chunk we want to situate:
 </chunk>
 Please give a short succinct context to situate this chunk within the overall document for the purposes of improving search retrieval of the chunk. Answer only with the succinct context and nothing else."""
 
+GROUP_SUMMARY_PROMPT = """You are summarizing section {group_index} of {total_groups} of a larger document. Produce:
+1. A summary of this section (2-3 sentences)
+2. section_summaries (a list of objects with "heading" and "summary" for each major section within this portion)
+
+<document_section>
+{group_text}
+</document_section>
+
+Return valid JSON with this exact structure:
+{{"summary": "...", "section_summaries": [{{"heading": "...", "summary": "..."}}]}}"""
+
 
 class EnrichmentClient:
     def __init__(self) -> None:
@@ -89,6 +100,32 @@ class EnrichmentClient:
         except Exception as e:
             logger.warning(f"Summary generation failed: {e}")
             return {"document_summary": "", "section_summaries": []}
+
+    async def generate_group_summary(
+        self, group_text: str, group_index: int, total_groups: int
+    ) -> dict:
+        """Summarize a group of parent chunks (map phase of hierarchical summarization)."""
+        try:
+            response = await self._client.chat.completions.create(
+                model=settings.enrichment_model,
+                max_tokens=16384,
+                response_format={"type": "json_object"},
+                messages=[
+                    {
+                        "role": "user",
+                        "content": GROUP_SUMMARY_PROMPT.format(
+                            group_text=group_text,
+                            group_index=group_index,
+                            total_groups=total_groups,
+                        ),
+                    }
+                ],
+            )
+            text = (response.choices[0].message.content or "").strip()
+            return json.loads(text)
+        except Exception as e:
+            logger.warning(f"Group summary generation failed: {e}")
+            return {"summary": "", "section_summaries": []}
 
     async def generate_context_with_summary(
         self,

--- a/src/agentdrive/enrichment/client.py
+++ b/src/agentdrive/enrichment/client.py
@@ -54,6 +54,15 @@ GROUP_SUMMARY_PROMPT = """You are summarizing section {group_index} of {total_gr
 Return valid JSON with this exact structure:
 {{"summary": "...", "section_summaries": [{{"heading": "...", "summary": "..."}}]}}"""
 
+REDUCE_SUMMARY_PROMPT = """Below are summaries of consecutive sections of a large document. Synthesize them into:
+1. A document_summary (2-3 sentences describing the document's purpose, parties involved, and subject matter)
+2. section_summaries (a merged, deduplicated list of objects with "heading" and "summary" covering the entire document)
+
+{group_summaries_text}
+
+Return valid JSON with this exact structure:
+{{"document_summary": "...", "section_summaries": [{{"heading": "...", "summary": "..."}}]}}"""
+
 
 class EnrichmentClient:
     def __init__(self) -> None:
@@ -126,6 +135,41 @@ class EnrichmentClient:
         except Exception as e:
             logger.warning(f"Group summary generation failed: {e}")
             return {"summary": "", "section_summaries": []}
+
+    async def generate_reduce_summary(self, group_summaries: list[dict]) -> dict:
+        """Synthesize group summaries into a final document summary (reduce phase)."""
+        parts = []
+        for i, group in enumerate(group_summaries, 1):
+            sections_text = "\n".join(
+                f"  - {s['heading']}: {s['summary']}"
+                for s in group.get("section_summaries", [])
+            )
+            parts.append(
+                f"Group {i} (of {len(group_summaries)}):\n"
+                f"Summary: {group.get('summary', '')}\n"
+                f"Sections:\n{sections_text}"
+            )
+        group_summaries_text = "\n\n".join(parts)
+
+        try:
+            response = await self._client.chat.completions.create(
+                model=settings.enrichment_model,
+                max_tokens=16384,
+                response_format={"type": "json_object"},
+                messages=[
+                    {
+                        "role": "user",
+                        "content": REDUCE_SUMMARY_PROMPT.format(
+                            group_summaries_text=group_summaries_text
+                        ),
+                    }
+                ],
+            )
+            text = (response.choices[0].message.content or "").strip()
+            return json.loads(text)
+        except Exception as e:
+            logger.warning(f"Reduce summary generation failed: {e}")
+            return {"document_summary": "", "section_summaries": []}
 
     async def generate_context_with_summary(
         self,

--- a/src/agentdrive/enrichment/contextual.py
+++ b/src/agentdrive/enrichment/contextual.py
@@ -41,6 +41,20 @@ async def generate_document_summary(document_text: str) -> dict:
     return await client.generate_summary(document_text)
 
 
+async def generate_group_summary(
+    group_text: str, group_index: int, total_groups: int
+) -> dict:
+    """Summarize a group of parent chunks (map phase of hierarchical summarization)."""
+    client = EnrichmentClient()
+    return await client.generate_group_summary(group_text, group_index, total_groups)
+
+
+async def generate_reduce_summary(group_summaries: list[dict]) -> dict:
+    """Synthesize group summaries into a final document summary (reduce phase)."""
+    client = EnrichmentClient()
+    return await client.generate_reduce_summary(group_summaries)
+
+
 def _find_section_summary(
     chunk_content: str, section_summaries: list[dict]
 ) -> str:

--- a/src/agentdrive/services/ingest.py
+++ b/src/agentdrive/services/ingest.py
@@ -26,6 +26,9 @@ from agentdrive.services.storage import StorageService
 logger = logging.getLogger(__name__)
 registry = ChunkerRegistry()
 
+MAX_SINGLE_PASS_TOKENS = 200_000
+GROUP_BATCH_TOKENS = 50_000
+
 
 async def process_file(file_id: uuid.UUID, session: AsyncSession) -> None:
     """Orchestrate file ingestion with four phases and resume support."""
@@ -213,6 +216,28 @@ async def _phase1_chunking(
                 tmp_path.unlink(missing_ok=True)
             except OSError:
                 pass
+
+
+def _batch_parents(parents: list) -> list[list]:
+    """Group parent chunks into batches of ~GROUP_BATCH_TOKENS tokens each."""
+    if not parents:
+        return []
+    batches: list[list] = []
+    current_batch: list = []
+    current_tokens = 0
+
+    for parent in parents:
+        token_count = parent.token_count
+        if current_batch and current_tokens + token_count > GROUP_BATCH_TOKENS:
+            batches.append(current_batch)
+            current_batch = []
+            current_tokens = 0
+        current_batch.append(parent)
+        current_tokens += token_count
+
+    if current_batch:
+        batches.append(current_batch)
+    return batches
 
 
 async def _phase2_summarization(

--- a/src/agentdrive/services/ingest.py
+++ b/src/agentdrive/services/ingest.py
@@ -13,6 +13,8 @@ from agentdrive.embedding.pipeline import embed_file_aliases, embed_file_chunks
 from agentdrive.enrichment.contextual import (
     enrich_chunks_with_summaries,
     generate_document_summary,
+    generate_group_summary,
+    generate_reduce_summary,
 )
 from agentdrive.enrichment.table_questions import generate_table_aliases
 from agentdrive.models.chunk import Chunk, ParentChunk
@@ -240,6 +242,23 @@ def _batch_parents(parents: list) -> list[list]:
     return batches
 
 
+async def _hierarchical_summarize(parents: list) -> dict:
+    """Map-reduce summarization for large documents."""
+    batches = _batch_parents(parents)
+    semaphore = asyncio.Semaphore(5)
+
+    async def summarize_group(batch: list, index: int) -> dict:
+        async with semaphore:
+            group_text = "\n\n".join(p.content for p in batch)
+            return await generate_group_summary(group_text, index, len(batches))
+
+    group_summaries = await asyncio.gather(
+        *(summarize_group(batch, i + 1) for i, batch in enumerate(batches))
+    )
+
+    return await generate_reduce_summary(list(group_summaries))
+
+
 async def _phase2_summarization(
     file: File, session: AsyncSession
 ) -> FileSummary:
@@ -250,9 +269,16 @@ async def _phase2_summarization(
         .order_by(ParentChunk.created_at)
     )
     parents = result.scalars().all()
-    document_text = "\n\n".join(p.content for p in parents)
+    total_tokens = sum(p.token_count for p in parents)
 
-    summary_data = await generate_document_summary(document_text)
+    if total_tokens > MAX_SINGLE_PASS_TOKENS:
+        logger.info(
+            f"File {file.id}: {total_tokens} tokens exceeds threshold, using hierarchical summarization"
+        )
+        summary_data = await _hierarchical_summarize(parents)
+    else:
+        document_text = "\n\n".join(p.content for p in parents)
+        summary_data = await generate_document_summary(document_text)
 
     summary = FileSummary(
         file_id=file.id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,11 +30,19 @@ def mock_enrichment_and_embedding():
     async def _noop_summary(text):
         return {"document_summary": "", "section_summaries": []}
 
+    async def _noop_group_summary(*args, **kwargs):
+        return {"summary": "", "section_summaries": []}
+
+    async def _noop_reduce_summary(*args, **kwargs):
+        return {"document_summary": "", "section_summaries": []}
+
     with patch("agentdrive.services.ingest.embed_file_chunks", side_effect=_noop_embed), \
          patch("agentdrive.services.ingest.embed_file_aliases", side_effect=_noop_embed), \
          patch("agentdrive.services.ingest.enrich_chunks_with_summaries", side_effect=_noop_enrich), \
          patch("agentdrive.services.ingest.generate_document_summary", side_effect=_noop_summary), \
-         patch("agentdrive.services.ingest.generate_table_aliases", side_effect=_noop_aliases):
+         patch("agentdrive.services.ingest.generate_table_aliases", side_effect=_noop_aliases), \
+         patch("agentdrive.services.ingest.generate_group_summary", side_effect=_noop_group_summary), \
+         patch("agentdrive.services.ingest.generate_reduce_summary", side_effect=_noop_reduce_summary):
         yield
 
 

--- a/tests/enrichment/test_client.py
+++ b/tests/enrichment/test_client.py
@@ -163,3 +163,40 @@ async def test_generate_summary_fallback_on_error(mock_openai_cls):
     result = await client.generate_summary("doc text")
 
     assert result == {"document_summary": "", "section_summaries": []}
+
+
+@pytest.mark.asyncio
+@patch("agentdrive.enrichment.client.openai.AsyncOpenAI")
+async def test_generate_group_summary(mock_openai_cls):
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create.return_value = _mock_chat_response(
+        '{"summary": "This section covers revenue.", "section_summaries": [{"heading": "Q3 Revenue", "summary": "Revenue grew 34%."}]}'
+    )
+    mock_openai_cls.return_value = mock_client
+
+    client = EnrichmentClient()
+    result = await client.generate_group_summary(
+        group_text="Q3 revenue reached $4.2M, up 34% YoY...",
+        group_index=1,
+        total_groups=4,
+    )
+
+    assert result["summary"] == "This section covers revenue."
+    assert len(result["section_summaries"]) == 1
+    call_args = mock_client.chat.completions.create.call_args
+    assert call_args[1]["response_format"] == {"type": "json_object"}
+    content = call_args[1]["messages"][0]["content"]
+    assert "section 1 of 4" in content
+
+
+@pytest.mark.asyncio
+@patch("agentdrive.enrichment.client.openai.AsyncOpenAI")
+async def test_generate_group_summary_fallback_on_error(mock_openai_cls):
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create.side_effect = Exception("API error")
+    mock_openai_cls.return_value = mock_client
+
+    client = EnrichmentClient()
+    result = await client.generate_group_summary("text", 1, 4)
+
+    assert result == {"summary": "", "section_summaries": []}

--- a/tests/enrichment/test_client.py
+++ b/tests/enrichment/test_client.py
@@ -200,3 +200,42 @@ async def test_generate_group_summary_fallback_on_error(mock_openai_cls):
     result = await client.generate_group_summary("text", 1, 4)
 
     assert result == {"summary": "", "section_summaries": []}
+
+
+@pytest.mark.asyncio
+@patch("agentdrive.enrichment.client.openai.AsyncOpenAI")
+async def test_generate_reduce_summary(mock_openai_cls):
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create.return_value = _mock_chat_response(
+        '{"document_summary": "Annual financial report.", "section_summaries": [{"heading": "Revenue", "summary": "Revenue grew."}]}'
+    )
+    mock_openai_cls.return_value = mock_client
+
+    group_summaries = [
+        {"summary": "Section covers revenue.", "section_summaries": [{"heading": "Q3 Revenue", "summary": "Revenue grew 34%."}]},
+        {"summary": "Section covers expenses.", "section_summaries": [{"heading": "Operating Costs", "summary": "Costs decreased."}]},
+    ]
+
+    client = EnrichmentClient()
+    result = await client.generate_reduce_summary(group_summaries)
+
+    assert result["document_summary"] == "Annual financial report."
+    assert len(result["section_summaries"]) == 1
+    call_args = mock_client.chat.completions.create.call_args
+    assert call_args[1]["response_format"] == {"type": "json_object"}
+    content = call_args[1]["messages"][0]["content"]
+    assert "Group 1" in content
+    assert "Group 2" in content
+
+
+@pytest.mark.asyncio
+@patch("agentdrive.enrichment.client.openai.AsyncOpenAI")
+async def test_generate_reduce_summary_fallback_on_error(mock_openai_cls):
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create.side_effect = Exception("API error")
+    mock_openai_cls.return_value = mock_client
+
+    client = EnrichmentClient()
+    result = await client.generate_reduce_summary([{"summary": "test", "section_summaries": []}])
+
+    assert result == {"document_summary": "", "section_summaries": []}

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -6,6 +6,7 @@ import pytest
 
 from agentdrive.services.ingest import (
     _batch_parents,
+    _hierarchical_summarize,
     _phase2_summarization,
     GROUP_BATCH_TOKENS,
     MAX_SINGLE_PASS_TOKENS,
@@ -121,3 +122,32 @@ async def test_phase2_large_doc_uses_hierarchical(mock_gen_summary, mock_hier):
     mock_gen_summary.assert_not_called()
     mock_hier.assert_called_once()
     assert summary.document_summary == "A large doc."
+
+
+@pytest.mark.asyncio
+@patch("agentdrive.services.ingest.generate_reduce_summary", new_callable=AsyncMock)
+@patch("agentdrive.services.ingest.generate_group_summary", new_callable=AsyncMock)
+async def test_hierarchical_summarize_map_reduce_flow(mock_group, mock_reduce):
+    """Verifies map phase calls generate_group_summary per batch, then reduce combines them."""
+    mock_group.side_effect = [
+        {"summary": "Group 1 summary.", "section_summaries": [{"heading": "A", "summary": "a"}]},
+        {"summary": "Group 2 summary.", "section_summaries": [{"heading": "B", "summary": "b"}]},
+    ]
+    mock_reduce.return_value = {
+        "document_summary": "Full doc summary.",
+        "section_summaries": [{"heading": "A", "summary": "a"}, {"heading": "B", "summary": "b"}],
+    }
+
+    # 4 parents at 20k tokens each = 80k total → 2 batches of 2 at 50k threshold
+    parents = [MagicMock(content=f"content {i}", token_count=20_000) for i in range(4)]
+
+    result = await _hierarchical_summarize(parents)
+
+    # Map phase: 2 batches → 2 group summary calls
+    assert mock_group.call_count == 2
+    # Reduce phase: called once with both group summaries
+    mock_reduce.assert_called_once()
+    reduce_args = mock_reduce.call_args[0][0]
+    assert len(reduce_args) == 2
+    assert result["document_summary"] == "Full doc summary."
+    assert len(result["section_summaries"]) == 2

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+
+import pytest
+
+from agentdrive.services.ingest import _batch_parents, GROUP_BATCH_TOKENS
+
+
+@dataclass
+class FakeParent:
+    content: str
+    token_count: int
+
+
+def _make_parent(tokens: int) -> FakeParent:
+    """Create a fake parent with approximate content length for given token count."""
+    return FakeParent(content="x " * tokens, token_count=tokens)
+
+
+def test_batch_parents_single_batch():
+    """All parents fit in one batch."""
+    parents = [_make_parent(1000) for _ in range(3)]
+    batches = _batch_parents(parents)
+    assert len(batches) == 1
+    assert len(batches[0]) == 3
+
+
+def test_batch_parents_multiple_batches():
+    """Parents split across batches at GROUP_BATCH_TOKENS boundary."""
+    # 5 parents at 20k each = 100k total. Batching: [p1+p2]=40k, [p3+p4]=40k, [p5]=20k -> 3 batches
+    parents = [_make_parent(20_000) for _ in range(5)]
+    batches = _batch_parents(parents)
+    assert len(batches) == 3
+    # All parents accounted for
+    total = sum(len(b) for b in batches)
+    assert total == 5
+
+
+def test_batch_parents_oversized_single_parent():
+    """A parent exceeding GROUP_BATCH_TOKENS gets its own batch."""
+    parents = [
+        _make_parent(60_000),  # exceeds 50k, gets own batch
+        _make_parent(10_000),
+        _make_parent(10_000),
+    ]
+    batches = _batch_parents(parents)
+    assert len(batches) == 2
+    assert len(batches[0]) == 1  # oversized parent alone
+    assert len(batches[1]) == 2  # remaining two fit together
+
+
+def test_batch_parents_empty():
+    """No parents produces no batches."""
+    batches = _batch_parents([])
+    assert batches == []
+
+
+def test_batch_parents_preserves_order():
+    """Batches preserve original parent ordering."""
+    parents = [_make_parent(20_000) for _ in range(4)]
+    batches = _batch_parents(parents)
+    flat = [p for batch in batches for p in batch]
+    assert flat == parents

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -1,8 +1,15 @@
 from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 import pytest
 
-from agentdrive.services.ingest import _batch_parents, GROUP_BATCH_TOKENS
+from agentdrive.services.ingest import (
+    _batch_parents,
+    _phase2_summarization,
+    GROUP_BATCH_TOKENS,
+    MAX_SINGLE_PASS_TOKENS,
+)
 
 
 @dataclass
@@ -60,3 +67,57 @@ def test_batch_parents_preserves_order():
     batches = _batch_parents(parents)
     flat = [p for batch in batches for p in batch]
     assert flat == parents
+
+
+def _mock_session(parents):
+    """Create a mock AsyncSession that returns given parents from execute()."""
+    session = MagicMock()
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = parents
+    # session.execute is async, returns result_mock
+    session.execute = AsyncMock(return_value=result_mock)
+    # session.add is sync (SQLAlchemy), session.commit is async
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    return session
+
+
+@pytest.mark.asyncio
+@patch("agentdrive.services.ingest.generate_document_summary", new_callable=AsyncMock)
+async def test_phase2_small_doc_uses_single_pass(mock_gen_summary):
+    """Documents under MAX_SINGLE_PASS_TOKENS use generate_document_summary directly."""
+    mock_gen_summary.return_value = {
+        "document_summary": "A short doc.",
+        "section_summaries": [],
+    }
+
+    file = MagicMock(id=uuid4())
+    parent = MagicMock(content="short text", token_count=100)
+    session = _mock_session([parent])
+
+    summary = await _phase2_summarization(file, session)
+
+    mock_gen_summary.assert_called_once()
+    assert summary.document_summary == "A short doc."
+
+
+@pytest.mark.asyncio
+@patch("agentdrive.services.ingest._hierarchical_summarize", new_callable=AsyncMock)
+@patch("agentdrive.services.ingest.generate_document_summary", new_callable=AsyncMock)
+async def test_phase2_large_doc_uses_hierarchical(mock_gen_summary, mock_hier):
+    """Documents over MAX_SINGLE_PASS_TOKENS use _hierarchical_summarize."""
+    mock_hier.return_value = {
+        "document_summary": "A large doc.",
+        "section_summaries": [{"heading": "Intro", "summary": "Intro text."}],
+    }
+
+    file = MagicMock(id=uuid4())
+    # Each parent has 50k tokens, 5 parents = 250k > 200k threshold
+    parents = [MagicMock(content="x " * 1000, token_count=50_000) for _ in range(5)]
+    session = _mock_session(parents)
+
+    summary = await _phase2_summarization(file, session)
+
+    mock_gen_summary.assert_not_called()
+    mock_hier.assert_called_once()
+    assert summary.document_summary == "A large doc."


### PR DESCRIPTION
## Summary

- Adds a 200k token threshold gate to Phase 2 summarization. Documents under the threshold use the existing single-call path (unchanged). Documents over use a map-reduce approach: batch parent chunks into ~50k-token groups, summarize each concurrently (semaphore-limited to 5), then reduce into a final summary.
- Output contract (`FileSummary` with `document_summary` + `section_summaries`) is identical regardless of which path runs. Phase 3 enrichment is unaffected.
- Preventative change — current doc ceiling is ~100 pages (~70k tokens), well under the threshold. This is a safety valve for when document sizes grow.

Closes #27

## Test Plan

- [ ] `uv run pytest tests/test_summarization.py -v` — 8 new tests covering batching logic, threshold routing, and end-to-end map-reduce flow
- [ ] `uv run pytest tests/enrichment/test_client.py -v` — 4 new tests for `generate_group_summary` and `generate_reduce_summary` client methods
- [ ] `uv run pytest tests/ -v` — full suite passes (233 tests)