### PR TITLE
fix(mcp): bump to 0.1.6 + add version bump check to CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/agentdrive-mcp/${PKG_VERSION}/json")
           if [ "$STATUS" = "200" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Version ${PKG_VERSION} already on PyPI — skipping publish"
+            echo "::warning::Version ${PKG_VERSION} already on PyPI — skipping publish. If you changed MCP code, bump the version in packages/mcp/pyproject.toml."
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "Version ${PKG_VERSION} not on PyPI — will publish"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,3 +50,41 @@ jobs:
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5434/agentdrive_test
         run: uv run pytest tests/ -v --ignore=tests/e2e
+
+  mcp-version-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+
+      - name: Check MCP version bump
+        run: |
+          # Check if MCP package files changed in this PR
+          MCP_CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- packages/mcp/ | wc -l)
+
+          if [ "$MCP_CHANGED" -eq "0" ]; then
+            echo "No MCP changes — skipping version check"
+            exit 0
+          fi
+
+          PR_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('packages/mcp/pyproject.toml','rb'))['project']['version'])")
+          BASE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('base/packages/mcp/pyproject.toml','rb'))['project']['version'])")
+
+          echo "Base version: $BASE_VERSION"
+          echo "PR version:   $PR_VERSION"
+
+          if [ "$PR_VERSION" = "$BASE_VERSION" ]; then
+            echo "::error::MCP package files changed but version was not bumped ($PR_VERSION). Update version in packages/mcp/pyproject.toml."
+            exit 1
+          fi
+
+          echo "Version bumped: $BASE_VERSION → $PR_VERSION"

--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentdrive-mcp"
-version = "0.1.5"
+version = "0.1.6"
 description = "Agent Drive MCP server for Claude Code"
 readme = "README.md"
 license = "MIT"

--- a/src/agentdrive/mcp/server.py
+++ b/src/agentdrive/mcp/server.py
@@ -1,5 +1,6 @@
 import json
 import os
+import uuid
 from pathlib import Path
 import httpx
 from mcp.server import Server
@@ -30,17 +31,35 @@ def _headers() -> dict:
     return {"Authorization": f"Bearer {AGENT_DRIVE_API_KEY}"}
 
 
+async def _resolve_kb_id(client: httpx.AsyncClient, kb_name_or_id: str) -> str | None:
+    """Resolve KB name to ID. Returns ID string or None."""
+    try:
+        uuid.UUID(kb_name_or_id)
+        return kb_name_or_id  # Already a UUID
+    except ValueError:
+        pass
+    resp = await client.get("/v1/knowledge-bases")
+    if resp.status_code != 200:
+        return None
+    for kb in resp.json().get("knowledge_bases", []):
+        if kb["name"] == kb_name_or_id:
+            return kb["id"]
+    return None
+
+
 @server.list_tools()
 async def list_tools() -> list[Tool]:
     return [
         Tool(name="upload_file", description="Upload a file to Agent Drive for processing and semantic indexing.",
              inputSchema={"type": "object", "properties": {
                  "path": {"type": "string", "description": "Absolute path to the file on disk"},
+                 "kb": {"type": "string", "description": "Optional knowledge base name or ID to add the file to after upload"},
              }, "required": ["path"]}),
-        Tool(name="search", description="Search across all uploaded files using natural language.",
+        Tool(name="search", description="Search across all uploaded files using natural language. Optionally scope to a knowledge base.",
              inputSchema={"type": "object", "properties": {
                  "query": {"type": "string", "description": "Natural language search query"},
                  "top_k": {"type": "integer", "description": "Number of results (default 5)", "default": 5},
+                 "kb": {"type": "string", "description": "Optional knowledge base name or ID to search within"},
              }, "required": ["query"]}),
         Tool(name="get_file_status", description="Check the processing status of an uploaded file.",
              inputSchema={"type": "object", "properties": {
@@ -85,6 +104,74 @@ async def list_tools() -> list[Tool]:
              inputSchema={"type": "object", "properties": {
                  "key_id": {"type": "string", "description": "UUID of the key to revoke"},
              }, "required": ["key_id"]}),
+        # Knowledge base tools
+        Tool(name="create_knowledge_base", description="Create a new knowledge base to organize files and generate synthesized knowledge articles.",
+             inputSchema={"type": "object", "properties": {
+                 "name": {"type": "string", "description": "Name for the knowledge base"},
+                 "description": {"type": "string", "description": "Optional description"},
+             }, "required": ["name"]}),
+        Tool(name="list_knowledge_bases", description="List all knowledge bases.",
+             inputSchema={"type": "object", "properties": {}}),
+        Tool(name="get_knowledge_base", description="Get details of a knowledge base by name or ID.",
+             inputSchema={"type": "object", "properties": {
+                 "kb": {"type": "string", "description": "Knowledge base name or ID"},
+             }, "required": ["kb"]}),
+        Tool(name="delete_knowledge_base", description="Delete a knowledge base. Articles are deleted but files are kept.",
+             inputSchema={"type": "object", "properties": {
+                 "kb": {"type": "string", "description": "Knowledge base name or ID"},
+             }, "required": ["kb"]}),
+        Tool(name="add_files_to_kb", description="Add files to a knowledge base. Triggers compilation.",
+             inputSchema={"type": "object", "properties": {
+                 "kb": {"type": "string", "description": "Knowledge base name or ID"},
+                 "file_ids": {"type": "array", "items": {"type": "string"}, "description": "List of file IDs to add"},
+             }, "required": ["kb", "file_ids"]}),
+        Tool(name="remove_files_from_kb", description="Remove files from a knowledge base. Affected articles are marked stale.",
+             inputSchema={"type": "object", "properties": {
+                 "kb": {"type": "string", "description": "Knowledge base name or ID"},
+                 "file_ids": {"type": "array", "items": {"type": "string"}, "description": "List of file IDs to remove"},
+             }, "required": ["kb", "file_ids"]}),
+        Tool(name="search_kb", description="Search within a knowledge base. Returns both chunks and synthesized articles.",
+             inputSchema={"type": "object", "properties": {
+                 "kb": {"type": "string", "description": "Knowledge base name or ID"},
+                 "query": {"type": "string", "description": "Search query"},
+                 "top_k": {"type": "integer", "description": "Number of results", "default": 5},
+                 "articles_only": {"type": "boolean", "description": "Only return articles", "default": False},
+             }, "required": ["kb", "query"]}),
+        Tool(name="get_article", description="Get a specific article from a knowledge base.",
+             inputSchema={"type": "object", "properties": {
+                 "kb": {"type": "string", "description": "Knowledge base name or ID"},
+                 "article_id": {"type": "string", "description": "Article ID"},
+             }, "required": ["kb", "article_id"]}),
+        Tool(name="list_articles", description="List articles in a knowledge base with optional filters.",
+             inputSchema={"type": "object", "properties": {
+                 "kb": {"type": "string", "description": "Knowledge base name or ID"},
+                 "category": {"type": "string"},
+                 "article_type": {"type": "string"},
+                 "limit": {"type": "integer", "default": 50},
+                 "offset": {"type": "integer", "default": 0},
+             }, "required": ["kb"]}),
+        Tool(name="compile_kb", description="Trigger compilation of a knowledge base to generate/update articles.",
+             inputSchema={"type": "object", "properties": {
+                 "kb": {"type": "string", "description": "Knowledge base name or ID"},
+                 "force": {"type": "boolean", "description": "Force full recompilation", "default": False},
+             }, "required": ["kb"]}),
+        Tool(name="health_check", description="Run health analysis on a knowledge base.",
+             inputSchema={"type": "object", "properties": {
+                 "kb": {"type": "string", "description": "Knowledge base name or ID"},
+                 "quick": {"type": "boolean", "description": "Quick mode (cheap checks only)", "default": False},
+             }, "required": ["kb"]}),
+        Tool(name="repair_kb", description="Execute repair actions on a knowledge base.",
+             inputSchema={"type": "object", "properties": {
+                 "kb": {"type": "string", "description": "Knowledge base name or ID"},
+                 "apply": {"type": "array", "items": {"type": "string"}, "description": "Actions to apply (e.g. 'stale', 'gaps')"},
+             }, "required": ["kb", "apply"]}),
+        Tool(name="derive_article", description="File a Q&A output back into a knowledge base as a derived article.",
+             inputSchema={"type": "object", "properties": {
+                 "kb": {"type": "string", "description": "Knowledge base name or ID"},
+                 "title": {"type": "string"},
+                 "content": {"type": "string", "description": "Article content in markdown"},
+                 "source_ids": {"type": "array", "items": {"type": "string"}, "description": "Optional chunk/article IDs that informed this"},
+             }, "required": ["kb", "title", "content"]}),
     ]
 
 
@@ -103,7 +190,16 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 with open(file_path, "rb") as f:
                     files = {"file": (file_path.name, f, "application/octet-stream")}
                     response = await client.post("/v1/files", files=files)
-                return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+                result = response.json()
+                # If kb specified, add file to knowledge base after upload
+                if arguments.get("kb") and response.status_code in (200, 201):
+                    kb_id = await _resolve_kb_id(client, arguments["kb"])
+                    if kb_id:
+                        file_id = result.get("id") or result.get("file_id")
+                        if file_id:
+                            await client.post(f"/v1/knowledge-bases/{kb_id}/files", json={"file_ids": [file_id]})
+                            result["added_to_kb"] = kb_id
+                return [TextContent(type="text", text=json.dumps(result, indent=2))]
             else:
                 # Signed URL flow for large files
                 url_body = {
@@ -131,10 +227,25 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                     return [TextContent(type="text", text=f"Error uploading to GCS: {put_response.status_code}")]
 
                 complete_response = await client.post(f"/v1/files/{file_id}/complete")
-                return [TextContent(type="text", text=json.dumps(complete_response.json(), indent=2))]
+                result = complete_response.json()
+                # If kb specified, add file to knowledge base after upload
+                if arguments.get("kb") and complete_response.status_code in (200, 201):
+                    kb_id = await _resolve_kb_id(client, arguments["kb"])
+                    if kb_id:
+                        await client.post(f"/v1/knowledge-bases/{kb_id}/files", json={"file_ids": [file_id]})
+                        result["added_to_kb"] = kb_id
+                return [TextContent(type="text", text=json.dumps(result, indent=2))]
         elif name == "search":
             body = {"query": arguments["query"], "top_k": arguments.get("top_k", 5)}
-            response = await client.post("/v1/search", json=body)
+            if arguments.get("kb"):
+                kb_id = await _resolve_kb_id(client, arguments["kb"])
+                if not kb_id:
+                    return [TextContent(type="text", text=f"Knowledge base '{arguments['kb']}' not found")]
+                if "articles_only" in arguments:
+                    body["articles_only"] = arguments["articles_only"]
+                response = await client.post(f"/v1/knowledge-bases/{kb_id}/search", json=body)
+            else:
+                response = await client.post("/v1/search", json=body)
             return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
         elif name == "get_file_status":
             response = await client.get(f"/v1/files/{arguments['file_id']}")
@@ -230,6 +341,102 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             response = await client.delete(f"/v1/api-keys/{arguments['key_id']}")
             if response.status_code == 204:
                 return [TextContent(type="text", text="API key revoked successfully.")]
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        # Knowledge base tools
+        elif name == "create_knowledge_base":
+            body: dict = {"name": arguments["name"]}
+            if "description" in arguments:
+                body["description"] = arguments["description"]
+            response = await client.post("/v1/knowledge-bases", json=body)
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        elif name == "list_knowledge_bases":
+            response = await client.get("/v1/knowledge-bases")
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        elif name == "get_knowledge_base":
+            kb_id = await _resolve_kb_id(client, arguments["kb"])
+            if not kb_id:
+                return [TextContent(type="text", text=f"Knowledge base '{arguments['kb']}' not found")]
+            response = await client.get(f"/v1/knowledge-bases/{kb_id}")
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        elif name == "delete_knowledge_base":
+            kb_id = await _resolve_kb_id(client, arguments["kb"])
+            if not kb_id:
+                return [TextContent(type="text", text=f"Knowledge base '{arguments['kb']}' not found")]
+            response = await client.delete(f"/v1/knowledge-bases/{kb_id}")
+            if response.status_code == 204:
+                return [TextContent(type="text", text="Knowledge base deleted successfully.")]
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        elif name == "add_files_to_kb":
+            kb_id = await _resolve_kb_id(client, arguments["kb"])
+            if not kb_id:
+                return [TextContent(type="text", text=f"Knowledge base '{arguments['kb']}' not found")]
+            response = await client.post(f"/v1/knowledge-bases/{kb_id}/files", json={"file_ids": arguments["file_ids"]})
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        elif name == "remove_files_from_kb":
+            kb_id = await _resolve_kb_id(client, arguments["kb"])
+            if not kb_id:
+                return [TextContent(type="text", text=f"Knowledge base '{arguments['kb']}' not found")]
+            response = await client.post(f"/v1/knowledge-bases/{kb_id}/files/remove", json={"file_ids": arguments["file_ids"]})
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        elif name == "search_kb":
+            kb_id = await _resolve_kb_id(client, arguments["kb"])
+            if not kb_id:
+                return [TextContent(type="text", text=f"Knowledge base '{arguments['kb']}' not found")]
+            body = {"query": arguments["query"], "top_k": arguments.get("top_k", 5),
+                    "articles_only": arguments.get("articles_only", False)}
+            response = await client.post(f"/v1/knowledge-bases/{kb_id}/search", json=body)
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        elif name == "get_article":
+            kb_id = await _resolve_kb_id(client, arguments["kb"])
+            if not kb_id:
+                return [TextContent(type="text", text=f"Knowledge base '{arguments['kb']}' not found")]
+            response = await client.get(f"/v1/knowledge-bases/{kb_id}/articles/{arguments['article_id']}")
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        elif name == "list_articles":
+            kb_id = await _resolve_kb_id(client, arguments["kb"])
+            if not kb_id:
+                return [TextContent(type="text", text=f"Knowledge base '{arguments['kb']}' not found")]
+            params: dict = {}
+            if "category" in arguments:
+                params["category"] = arguments["category"]
+            if "article_type" in arguments:
+                params["article_type"] = arguments["article_type"]
+            params["limit"] = arguments.get("limit", 50)
+            params["offset"] = arguments.get("offset", 0)
+            response = await client.get(f"/v1/knowledge-bases/{kb_id}/articles", params=params)
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        elif name == "compile_kb":
+            kb_id = await _resolve_kb_id(client, arguments["kb"])
+            if not kb_id:
+                return [TextContent(type="text", text=f"Knowledge base '{arguments['kb']}' not found")]
+            params = {}
+            if arguments.get("force"):
+                params["force"] = "true"
+            response = await client.post(f"/v1/knowledge-bases/{kb_id}/compile", params=params)
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        elif name == "health_check":
+            kb_id = await _resolve_kb_id(client, arguments["kb"])
+            if not kb_id:
+                return [TextContent(type="text", text=f"Knowledge base '{arguments['kb']}' not found")]
+            params = {}
+            if arguments.get("quick"):
+                params["quick"] = "true"
+            response = await client.post(f"/v1/knowledge-bases/{kb_id}/health-check", params=params)
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        elif name == "repair_kb":
+            kb_id = await _resolve_kb_id(client, arguments["kb"])
+            if not kb_id:
+                return [TextContent(type="text", text=f"Knowledge base '{arguments['kb']}' not found")]
+            response = await client.post(f"/v1/knowledge-bases/{kb_id}/repair", json={"apply": arguments["apply"]})
+            return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
+        elif name == "derive_article":
+            kb_id = await _resolve_kb_id(client, arguments["kb"])
+            if not kb_id:
+                return [TextContent(type="text", text=f"Knowledge base '{arguments['kb']}' not found")]
+            body = {"title": arguments["title"], "content": arguments["content"]}
+            if "source_ids" in arguments:
+                body["source_ids"] = arguments["source_ids"]
+            response = await client.post(f"/v1/knowledge-bases/{kb_id}/articles/derived", json=body)
             return [TextContent(type="text", text=json.dumps(response.json(), indent=2))]
         return [TextContent(type="text", text=f"Unknown tool: {name}")]
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -25,7 +25,20 @@ async def test_list_tools():
     assert "list_api_keys" in tool_names
     assert "revoke_api_key" in tool_names
     assert "download_file" in tool_names
-    assert len(tool_names) == 10
+    assert "create_knowledge_base" in tool_names
+    assert "list_knowledge_bases" in tool_names
+    assert "get_knowledge_base" in tool_names
+    assert "delete_knowledge_base" in tool_names
+    assert "add_files_to_kb" in tool_names
+    assert "remove_files_from_kb" in tool_names
+    assert "search_kb" in tool_names
+    assert "get_article" in tool_names
+    assert "list_articles" in tool_names
+    assert "compile_kb" in tool_names
+    assert "health_check" in tool_names
+    assert "repair_kb" in tool_names
+    assert "derive_article" in tool_names
+    assert len(tool_names) == 23
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Bumps `agentdrive-mcp` from 0.1.5 → 0.1.6 so the KB tools actually get published to PyPI (0.1.5 was published before the KB layer PR)
- Adds `mcp-version-check` job to test.yml that **fails PRs** which change `packages/mcp/` files without bumping the version — prevents this from happening again
- Adds warning annotation to publish.yml when version already exists on PyPI

## Context

PR #29 added 13 KB tools to the MCP package but didn't bump the version. The publish workflow saw 0.1.5 already on PyPI, silently skipped, and reported success. Users couldn't access the new tools.

## Test Plan

- [ ] CI `mcp-version-check` job runs on this PR (should pass since version changed)
- [ ] After merge, publish workflow publishes 0.1.6 to PyPI
- [ ] `uvx agentdrive-mcp@latest serve` picks up KB tools