### PR TITLE
fix(mcp): remove broken agentdrive dep, bump to 0.1.7

### DIFF
--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentdrive-mcp"
-version = "0.1.6"
+version = "0.1.7"
 description = "Agent Drive MCP server for Claude Code"
 readme = "README.md"
 license = "MIT"
@@ -15,7 +15,7 @@ dependencies = [
     "mcp>=1.0.0",
     "httpx>=0.28.0",
     "typer>=0.15.0",
-    "agentdrive>=0.1.0",
+
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

`agentdrive>=0.1.0` was added as a dependency in 0.1.5, but `agentdrive` is not published to PyPI. This made 0.1.5 and 0.1.6 **uninstallable** — `uvx` silently fell back to cached 0.1.4, which is why the 13 KB tools never appeared for users.

## Fix

- Remove `agentdrive>=0.1.0` from dependencies (MCP server talks to API over HTTP, doesn't import from the main package)
- Bump to 0.1.7

## Test Plan

- [ ] After merge, verify `uvx agentdrive-mcp@0.1.7 status` installs successfully
- [ ] Verify 23 tools appear in Claude Code after restart